### PR TITLE
kunai: init at 0.1.0-unstable-2025-06-07

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -13,6 +13,7 @@ _self: super: {
   jayrat = super.callPackage ../packages/jayrat.nix { };
   jira2markdown = super.callPackage ../packages/jira2markdown.nix { };
   kss = super.callPackage ../packages/kss.nix { };
+  kunai = super.callPackage ../packages/kunai.nix { };
   lazypr = super.callPackage ../packages/lazypr.nix { };
   lazyworktree = super.callPackage ../packages/lazyworktree.nix { };
   nextmeeting = super.callPackage ../packages/nextmeeting.nix { };

--- a/packages/kunai.nix
+++ b/packages/kunai.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kunai";
+  version = "0.1.0-unstable-2025-06-07";
+
+  src = fetchFromGitHub {
+    owner = "mikkurogue";
+    repo = "kunai";
+    rev = "494af5aabc9905a52a8cdbcdff2abe8d0184ef1a";
+    hash = "sha256-n3diNIAtEUhCkSshfALjme0epl90QJmIAyumt8Qx8Tc=";
+  };
+
+  cargoHash = "sha256-YPTh0SJTvIZFyF1ruNE1OPuP1oFmrjlsY+ChGwozvVM=";
+
+  meta = {
+    description = "Per-keyboard layout switcher for Niri compositor";
+    homepage = "https://github.com/mikkurogue/kunai";
+    license = lib.licenses.free;
+    mainProgram = "kunai";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Per-keyboard layout switcher for Niri compositor. Automatically switches keyboard layouts based on which physical keyboard you're typing on.

- **Upstream**: https://github.com/mikkurogue/kunai
- **Use case**: Different layouts for different physical keyboards (e.g., QWERTY laptop + Colemak mechanical)
- **How it works**: Monitors `/dev/input/event*` devices, switches niri layout via `niri msg` when typing on a mapped keyboard
- **Setup**: `kunai list` → `kunai setup` → `kunai daemon`